### PR TITLE
update plugin hints to jdaviz 4.1 (lcviz 1.1)

### DIFF
--- a/plugin_APIs.ipynb
+++ b/plugin_APIs.ipynb
@@ -9,8 +9,8 @@
     "\n",
     "This notebook demonstrates how to discover the API commands necessary to reproduce plugin workflows in the notebook.\n",
     "\n",
-    "* **Last Updated**: December 4, 2024\n",
-    "* **lcviz version**: 1.0.0"
+    "* **Last Updated**: March 25, 2025\n",
+    "* **lcviz version**: 1.1.0"
    ]
   },
   {
@@ -77,7 +77,19 @@
    "id": "7829e15b-54ca-49f8-94cf-77d31b25d634",
    "metadata": {},
    "source": [
-    "To access a list of available attributes and methods, call `dir(plugin_api_object)`"
+    "To access a list of available attributes and methods, call `dir(plugin_api_object)` or enable the API hints in the UI, by either clicking on the `[API]` button in the top bar or by calling `lcviz.toggle_api_hints()`.  By turning on API hints, the UI itself will show commands to reproduce the same actions of various inputs and buttons in the UI (including the commands to access the plugin APIs themselves)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "341e9999-fbdc-4529-95fe-b807b4ac9136",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "lcviz.toggle_api_hints()"
    ]
   },
   {
@@ -97,7 +109,7 @@
    "id": "36d476b2-9b5e-4200-8481-9e7acca2e531",
    "metadata": {},
    "source": [
-    "All plugins have `show()` (to show in-line in the notebook), `open_in_tray()` (to open in the sidebar tray), and `close_in_tray()` methods, as well as an `api_hints_enabled` attribute which can be set to `True` to help discover the uses of the remaining exposed API commands (**NOTE**: this will be changing in the next release to be a global switch).  Let's show this plugin-in line and then enable the API hints."
+    "All plugins have `show()` (to show in-line in the notebook), `open_in_tray()` (to open in the sidebar tray), and `close_in_tray()` methods to show the plugin."
    ]
   },
   {
@@ -114,24 +126,10 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e4d81082-befe-4909-9dbc-ad805b108dfd",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "plg.api_hints_enabled = True"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "66e42482-e414-4765-a38c-943520885ee6",
    "metadata": {},
    "source": [
-    "Note that the API hints are also togglable in the plugin UI itself with the `<>` button in the top right, and includes a hint for how to access the plugin object itself (`plg = lcviz.plugins['Flatten']`).\n",
-    "\n",
     "We can now use the UI to set options interactively, checking the live-preview of the flattening trend, and then writing a code block to reproduce those options in the notebook.  For example:"
    ]
   },


### PR DESCRIPTION
- [x] update header with released version of lcviz

**Waiting for**: ~jdaviz 4.1 release and subsequent lcviz release (https://github.com/spacetelescope/lcviz/pull/158)~