### PR TITLE
Updates for jdaviz 4.3 compatibility

### DIFF
--- a/mult_ephem_RR-Lyr.ipynb
+++ b/mult_ephem_RR-Lyr.ipynb
@@ -62,7 +62,7 @@
    "source": [
     "lcviz = LCviz()\n",
     "\n",
-    "lcviz.load_data(lc)\n",
+    "lcviz.load(lc)\n",
     "\n",
     "# we'll make use of these plugins later:\n",
     "eph = lcviz.plugins['Ephemeris']\n",

--- a/mult_ephem_kic_2835289.ipynb
+++ b/mult_ephem_kic_2835289.ipynb
@@ -26,7 +26,7 @@
     "lc = search_lightcurve(\"KIC 2835289\", author=\"Kepler\", cadence=\"long\", quarter=[9,11,13,15,17]).download_all().stitch()\n",
     "\n",
     "lcviz = LCviz()\n",
-    "lcviz.load_data(lc)\n",
+    "lcviz.load(lc)\n",
     "lcviz.show()"
    ]
   },

--- a/plugin_APIs.ipynb
+++ b/plugin_APIs.ipynb
@@ -175,7 +175,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.5"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,

--- a/short_cadence_phase_curve_HAT-P-7.ipynb
+++ b/short_cadence_phase_curve_HAT-P-7.ipynb
@@ -61,7 +61,7 @@
    "source": [
     "# Load the light curve into LCviz:\n",
     "lcviz = LCviz()\n",
-    "lcviz.load_data(lc, data_label=f\"HAT-P-7\")\n",
+    "lcviz.load(lc, data_label=f\"HAT-P-7\")\n",
     "lcviz.show()"
    ]
   },
@@ -160,11 +160,11 @@
     "\n",
     "plot_options = lcviz.plugins['Plot Options']\n",
     "plot_options.viewer = 'flux-vs-phase:default'\n",
-    "plot_options.layer = 'HAT-P-7 Q3'\n",
+    "plot_options.layer = 'HAT-P-7'\n",
     "plot_options.marker_opacity = 0.1\n",
     "plot_options.marker_size = 1\n",
     "\n",
-    "plot_options.layer = 'binned HAT-P-7 Q3:default'\n",
+    "plot_options.layer = 'binned HAT-P-7:default'\n",
     "plot_options.marker_size = 50\n",
     "plot_options.marker_color = 'r'"
    ]


### PR DESCRIPTION
Here are updates to match spacetelescope/lcviz#183. As mentioned in the review for 183, I can't load the TPF in the example notebook.